### PR TITLE
Safeguard simultaneous start of timestamp

### DIFF
--- a/src/test/java/com/farao_community/farao/gridcapa/job_launcher/service/JobLauncherServiceTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/job_launcher/service/JobLauncherServiceTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @SpringBootTest

--- a/src/test/java/com/farao_community/farao/gridcapa/job_launcher/service/JobLauncherServiceTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/job_launcher/service/JobLauncherServiceTest.java
@@ -91,6 +91,7 @@ class JobLauncherServiceTest {
     }
 
     @Test
+    @DisplayName("Testing that a timestamp is properly cleaned up after an exception occurs.")
     void testException() {
         final String timestamp = "2024-09-18T09:30Z";
         final TaskDto taskDto = new TaskDto(UUID.randomUUID(), OffsetDateTime.parse(timestamp), TaskStatus.ERROR, null, null, null, null, null, null);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced job launching to prevent duplicate executions and ensure reliable task processing.
- **Tests**
  - Added a test to verify that a job cannot be launched twice simultaneously for the same timestamp.
  - Added a test to handle exceptions during job launch attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->